### PR TITLE
fix: remove duplicate yellow dot on globe click

### DIFF
--- a/src/components/Globe.jsx
+++ b/src/components/Globe.jsx
@@ -144,7 +144,6 @@ const Globe = forwardRef(function Globe(
   const globeRef    = useRef(null);
   const rendererRef = useRef(null);
   const frameRef    = useRef(null);
-  const pinRef      = useRef(null);
 
   // Refs that the RAF loop reads without triggering re-renders
   const layerModeRef     = useRef(layerMode);
@@ -229,15 +228,6 @@ const Globe = forwardRef(function Globe(
       new THREE.SphereGeometry(EARTH_RADIUS * 1.06, 48, 48),
       new THREE.MeshBasicMaterial({ color: 0x2288ff, transparent: true, opacity: 0.04, side: THREE.BackSide }),
     ));
-
-    // Location pin
-    const pin = new THREE.Mesh(
-      new THREE.SphereGeometry(0.035, 12, 12),
-      new THREE.MeshBasicMaterial({ color: 0xffdd00 }),
-    );
-    pin.visible = false;
-    globe.add(pin);
-    pinRef.current = pin;
 
     // ── 2D label canvas overlay ─────────────────────────────────
     const labelCanvas = document.createElement('canvas');
@@ -417,14 +407,6 @@ const Globe = forwardRef(function Globe(
       })
       .catch(() => { borderLoadingRef.current = false; });
   }, [layerMode]);
-
-  // ── Update location pin ───────────────────────────────────────
-  useEffect(() => {
-    const pin = pinRef.current;
-    if (!pin || !selectedLocation) return;
-    latLonToVec3(selectedLocation.lat, selectedLocation.lon, EARTH_RADIUS * 1.015, pin.position);
-    pin.visible = true;
-  }, [selectedLocation]);
 
   return (
     <div className="globe-mount" ref={mountRef}>


### PR DESCRIPTION
Two yellow dots appeared on click — a 3D Three.js sphere pin and an HTML
.city-label-dot overlay projected from a higher radius (1.06 vs 1.015),
causing the second dot to render above the clicked point. Remove the 3D
pin mesh entirely; the HTML label dot is the single source of truth.

https://claude.ai/code/session_01PAU9y4kaefCfm53LNMp62X