### PR TITLE
Add landing page with globe hero and navigation to globe app

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,15 +20,15 @@ html, body, #root {
   background: var(--bg);
   color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-  overflow: hidden;
 }
 
-/* ── App Layout ────────────────────────────────────────────────── */
+/* ── App Layout (globe view) ───────────────────────────────────── */
 .app {
   display: flex;
   flex-direction: column;
   height: 100vh;
   width: 100vw;
+  overflow: hidden;
   background: radial-gradient(ellipse at 30% 40%, #0d1f4a 0%, #080d1a 60%);
 }
 
@@ -630,7 +630,7 @@ html, body, #root {
 
 /* ── Mobile layout (≤ 768px) ───────────────────────────────────── */
 @media (max-width: 768px) {
-  html, body, #root { overflow: hidden; }
+  .app { overflow: hidden; }
 
   .topbar {
     padding: 10px 14px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,12 +6,14 @@ import SearchBar from './components/SearchBar';
 import DateTime from './components/DateTime';
 import WeatherTicker from './components/WeatherTicker';
 import GlobeControls from './components/GlobeControls';
+import LandingPage from './components/LandingPage';
 import { fetchWeather, reverseGeocode, TICKER_CITIES } from './utils/api';
 import { useFavourites } from './hooks/useFavourites';
 
 const DEFAULT_LOCATION = { lat: 51.5074, lon: -0.1278, city: 'London', country: 'United Kingdom' };
 
 export default function App() {
+  const [showLanding, setShowLanding] = useState(true);
   const [location, setLocation]   = useState(DEFAULT_LOCATION);
   const [weather,  setWeather]    = useState(null);
   const [loading,  setLoading]    = useState(true);
@@ -83,6 +85,10 @@ export default function App() {
     ...tickerCities,
     location.city ? { ...location, lat: location.lat, lon: location.lon } : null,
   ].filter(Boolean);
+
+  if (showLanding) {
+    return <LandingPage onExplore={() => setShowLanding(false)} />;
+  }
 
   return (
     <div className="app">

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -1,0 +1,504 @@
+/* ── Landing page root ─────────────────────────────────────────── */
+.landing {
+  min-height: 100vh;
+  width: 100%;
+  background: #080d1a;
+  color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+/* ── Navbar ──────────────────────────────────────────────────────── */
+.landing-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 40px;
+  height: 58px;
+  background: rgba(8, 13, 26, 0.85);
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+  backdrop-filter: blur(14px);
+  gap: 24px;
+}
+
+.landing-nav-logo {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.landing-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  flex: 1;
+  padding-left: 32px;
+}
+
+.landing-nav-links a {
+  color: rgba(255,255,255,0.65);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 500;
+  transition: color 0.2s;
+  white-space: nowrap;
+}
+.landing-nav-links a:hover { color: #fff; }
+
+.landing-nav-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.landing-nav-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255,255,255,0.07);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 30px;
+  padding: 7px 16px;
+  color: rgba(255,255,255,0.4);
+}
+.landing-nav-search input {
+  background: none;
+  border: none;
+  outline: none;
+  color: #fff;
+  font-size: 13px;
+  width: 150px;
+}
+.landing-nav-search input::placeholder { color: rgba(255,255,255,0.4); }
+
+.landing-signin-btn {
+  background: #0077cc;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 20px;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+.landing-signin-btn:hover { background: #0088ee; }
+
+/* ── Hero ────────────────────────────────────────────────────────── */
+.landing-hero {
+  min-height: calc(100vh - 58px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(ellipse at 50% 45%, #0d1f4a 0%, #080d1a 65%);
+  padding: 60px 40px;
+  position: relative;
+  overflow: hidden;
+}
+
+.landing-hero-inner {
+  position: relative;
+  width: 100%;
+  max-width: 920px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 36px;
+}
+
+/* Globe visual */
+.landing-globe-wrap {
+  position: relative;
+  width: 460px;
+  height: 460px;
+  flex-shrink: 0;
+}
+
+.landing-globe-glow {
+  position: absolute;
+  inset: -40px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(0,100,200,0.25) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.landing-globe-ring {
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  border: 1px solid rgba(0,150,255,0.2);
+  box-shadow:
+    0 0 40px rgba(0,100,255,0.15),
+    inset 0 0 40px rgba(0,50,150,0.1);
+  pointer-events: none;
+}
+
+.landing-globe-img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+  box-shadow:
+    0 0 80px rgba(0,80,200,0.4),
+    0 0 160px rgba(0,40,120,0.25);
+  filter: brightness(0.85) saturate(1.1);
+}
+
+/* Floating city cards */
+.landing-city-card {
+  position: absolute;
+  background: rgba(10, 20, 50, 0.82);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 12px;
+  padding: 14px 18px;
+  backdrop-filter: blur(16px);
+  min-width: 160px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+
+.card-tokyo   { top: 10px;  left: -30px; }
+.card-london  { bottom: 60px; left: -20px; }
+.card-newyork { top: 50%; right: -20px; transform: translateY(-50%); }
+
+.lcc-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.lcc-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  color: rgba(255,255,255,0.55);
+}
+.lcc-temp {
+  font-size: 28px;
+  font-weight: 700;
+  line-height: 1;
+  margin-bottom: 4px;
+}
+.lcc-desc {
+  font-size: 11px;
+  color: rgba(255,255,255,0.5);
+  line-height: 1.4;
+}
+
+/* Hero text */
+.landing-hero-text {
+  text-align: center;
+  max-width: 640px;
+}
+
+.landing-hero-text h1 {
+  font-size: clamp(32px, 5vw, 52px);
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: -1px;
+  margin-bottom: 18px;
+}
+
+.landing-3d {
+  color: #00c8ff;
+}
+
+.landing-hero-text p {
+  font-size: 15px;
+  color: rgba(255,255,255,0.6);
+  line-height: 1.7;
+  max-width: 520px;
+  margin: 0 auto 28px;
+}
+
+.landing-hero-cta {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.landing-btn-primary {
+  background: #0077cc;
+  border: none;
+  border-radius: 10px;
+  padding: 14px 28px;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+.landing-btn-primary:hover { background: #0088ee; transform: translateY(-1px); }
+.landing-btn-primary:active { transform: translateY(0); }
+
+.landing-btn-secondary {
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 10px;
+  padding: 14px 28px;
+  color: #fff;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+.landing-btn-secondary:hover { background: rgba(255,255,255,0.13); transform: translateY(-1px); }
+.landing-btn-secondary:active { transform: translateY(0); }
+
+/* ── Section shared ──────────────────────────────────────────────── */
+.landing-section-inner {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ── Advanced Forecasting ────────────────────────────────────────── */
+.landing-features {
+  padding: 90px 40px;
+  background: #080d1a;
+}
+
+.landing-features h2 {
+  font-size: 30px;
+  font-weight: 800;
+  margin-bottom: 10px;
+}
+
+.landing-section-sub {
+  font-size: 15px;
+  color: rgba(255,255,255,0.5);
+  margin-bottom: 44px;
+  line-height: 1.6;
+}
+
+.landing-features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.landing-feature-card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: 14px;
+  padding: 28px 24px;
+  transition: border-color 0.2s, background 0.2s;
+}
+.landing-feature-card:hover {
+  border-color: rgba(0,200,255,0.2);
+  background: rgba(0,200,255,0.03);
+}
+
+.lfc-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background: rgba(0,100,200,0.18);
+  border: 1px solid rgba(0,150,255,0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #00c8ff;
+  margin-bottom: 18px;
+}
+
+.landing-feature-card h3 {
+  font-size: 17px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.landing-feature-card p {
+  font-size: 13px;
+  color: rgba(255,255,255,0.5);
+  line-height: 1.6;
+}
+
+/* ── Regional Deep-Dive ──────────────────────────────────────────── */
+.landing-regions {
+  padding: 0 40px 90px;
+  background: #080d1a;
+}
+
+.landing-regions h2 {
+  font-size: 30px;
+  font-weight: 800;
+  margin-bottom: 28px;
+}
+
+.landing-regions-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+}
+
+.landing-region-card {
+  position: relative;
+  height: 200px;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+.landing-region-card:hover { transform: translateY(-3px); }
+
+/* City-specific gradient backgrounds */
+.region-tokyo   { background: linear-gradient(135deg, #0d1a2e 0%, #1a2a4a 40%, #2a1a0a 100%); }
+.region-newyork { background: linear-gradient(135deg, #1a1a2e 0%, #2a2a4a 40%, #1a2a1a 100%); }
+.region-london  { background: linear-gradient(135deg, #0d1a1a 0%, #1a2a2a 40%, #1a1a2a 100%); }
+.region-dubai   { background: linear-gradient(135deg, #2a1a0a 0%, #1a2a2a 40%, #0d1a2e 100%); }
+
+/* Subtle inner detail for each city */
+.region-tokyo::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 60% 30%, rgba(255,150,50,0.25) 0%, transparent 50%),
+    radial-gradient(ellipse at 20% 70%, rgba(0,80,180,0.2) 0%, transparent 40%);
+}
+.region-newyork::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 20%, rgba(100,150,255,0.2) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 80%, rgba(50,100,200,0.15) 0%, transparent 40%);
+}
+.region-london::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 40% 30%, rgba(80,120,200,0.2) 0%, transparent 50%),
+    radial-gradient(ellipse at 70% 70%, rgba(60,100,160,0.15) 0%, transparent 40%);
+}
+.region-dubai::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 50% 20%, rgba(255,200,80,0.3) 0%, transparent 50%),
+    radial-gradient(ellipse at 30% 70%, rgba(200,150,50,0.2) 0%, transparent 40%);
+}
+
+.lrc-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(5,10,20,0.85) 0%, transparent 55%);
+}
+
+.lrc-name {
+  position: absolute;
+  bottom: 44px;
+  left: 14px;
+  font-size: 14px;
+  font-weight: 700;
+  z-index: 1;
+}
+
+.lrc-bottom {
+  position: absolute;
+  bottom: 14px;
+  left: 14px;
+  right: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 1;
+}
+
+.lrc-condition {
+  font-size: 12px;
+  color: rgba(255,255,255,0.6);
+}
+
+.lrc-temp {
+  font-size: 16px;
+  font-weight: 700;
+  color: #00c8ff;
+}
+
+/* ── Footer ──────────────────────────────────────────────────────── */
+.landing-footer {
+  background: rgba(5, 9, 18, 0.95);
+  border-top: 1px solid rgba(255,255,255,0.06);
+  padding: 28px 40px;
+}
+
+.landing-footer-inner {
+  max-width: 860px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 28px;
+  flex-wrap: wrap;
+}
+
+.landing-footer-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: rgba(255,255,255,0.3);
+  font-weight: 600;
+  line-height: 1.4;
+  margin-right: 8px;
+}
+
+.landing-footer a {
+  color: rgba(255,255,255,0.4);
+  text-decoration: none;
+  font-size: 13px;
+  transition: color 0.2s;
+}
+.landing-footer a:hover { color: rgba(255,255,255,0.7); }
+
+.landing-footer-copy {
+  margin-left: auto;
+  font-size: 12px;
+  color: rgba(255,255,255,0.25);
+}
+
+/* ── Responsive ──────────────────────────────────────────────────── */
+@media (max-width: 900px) {
+  .landing-nav { padding: 0 20px; }
+  .landing-nav-links { display: none; }
+  .landing-hero { padding: 40px 20px; }
+
+  .landing-globe-wrap {
+    width: 300px;
+    height: 300px;
+  }
+  .card-tokyo   { top: 0; left: -10px; }
+  .card-london  { bottom: 10px; left: -10px; }
+  .card-newyork { right: -10px; }
+
+  .landing-features,
+  .landing-regions { padding: 60px 20px; }
+
+  .landing-features-grid { grid-template-columns: 1fr; gap: 14px; }
+  .landing-regions-grid  { grid-template-columns: repeat(2, 1fr); }
+
+  .landing-footer { padding: 20px; }
+  .landing-footer-copy { margin-left: 0; width: 100%; }
+}
+
+@media (max-width: 520px) {
+  .landing-globe-wrap { width: 220px; height: 220px; }
+  .card-tokyo, .card-london, .card-newyork { display: none; }
+  .landing-regions-grid { grid-template-columns: 1fr 1fr; }
+  .landing-nav-search { display: none; }
+}

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -1,0 +1,185 @@
+import './LandingPage.css';
+
+const EARTH_TEXTURE = 'https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg';
+
+const CITY_CARDS = [
+  { id: 'tokyo',    label: 'TOKYO',    temp: '24°C', desc: 'Clear Skies • Humidity 45%', cls: 'card-tokyo' },
+  { id: 'london',   label: 'LONDON',   temp: '15°C', desc: 'Light Rain • Humidity 82%', cls: 'card-london' },
+  { id: 'new-york', label: 'NEW YORK', temp: '18°C', desc: 'Partly Cloudy • Wind 12mph', cls: 'card-newyork' },
+];
+
+const FEATURES = [
+  {
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M2 12h3M19 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12"/>
+      </svg>
+    ),
+    title: 'Live Storm Tracking',
+    desc: 'Watch hurricanes and pressure systems evolve in real-time with fluid 3D animations.',
+  },
+  {
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+      </svg>
+    ),
+    title: 'Glassmorphism UI',
+    desc: 'A sleek, dark theme designed for modern high-resolution displays and mobile devices.',
+  },
+  {
+    icon: (
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+      </svg>
+    ),
+    title: 'Global Coverage',
+    desc: 'Micro-climate data for every major city and remote location across all seven continents.',
+  },
+];
+
+const REGIONS = [
+  { name: 'Tokyo',    condition: 'Clear Sky', temp: '24°C', cls: 'region-tokyo' },
+  { name: 'New York', condition: 'Cloudy',    temp: '18°C', cls: 'region-newyork' },
+  { name: 'London',   condition: 'Raining',   temp: '15°C', cls: 'region-london' },
+  { name: 'Dubai',    condition: 'Sunny',     temp: '38°C', cls: 'region-dubai' },
+];
+
+export default function LandingPage({ onExplore }) {
+  return (
+    <div className="landing">
+      {/* ── Navbar ── */}
+      <nav className="landing-nav">
+        <div className="landing-nav-logo">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#00c8ff" strokeWidth="1.8">
+            <circle cx="12" cy="12" r="10"/>
+            <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+          </svg>
+          <span>Weather World</span>
+        </div>
+        <div className="landing-nav-links">
+          <a href="#" onClick={e => { e.preventDefault(); onExplore(); }}>Globe</a>
+          <a href="#">Forecast</a>
+          <a href="#">Radar Maps</a>
+          <a href="#">Climate Insights</a>
+        </div>
+        <div className="landing-nav-right">
+          <div className="landing-nav-search">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+            </svg>
+            <input placeholder="Search city..." />
+          </div>
+          <button className="landing-signin-btn">Sign In</button>
+        </div>
+      </nav>
+
+      {/* ── Hero ── */}
+      <section className="landing-hero">
+        <div className="landing-hero-inner">
+          {/* Globe visual */}
+          <div className="landing-globe-wrap">
+            <div className="landing-globe-glow" />
+            <div className="landing-globe-ring" />
+            <img
+              className="landing-globe-img"
+              src={EARTH_TEXTURE}
+              alt="Earth"
+              draggable="false"
+            />
+          </div>
+
+          {/* Floating city cards */}
+          {CITY_CARDS.map(c => (
+            <div key={c.id} className={`landing-city-card ${c.cls}`}>
+              <div className="lcc-header">
+                <span className="lcc-label">{c.label}</span>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#f5c518" strokeWidth="2">
+                  <circle cx="12" cy="12" r="5"/><path d="M12 2v2M12 20v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M2 12h2M20 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+                </svg>
+              </div>
+              <div className="lcc-temp">{c.temp}</div>
+              <div className="lcc-desc">{c.desc}</div>
+            </div>
+          ))}
+
+          {/* Hero text */}
+          <div className="landing-hero-text">
+            <h1>
+              Experience the World's<br />
+              Weather in <span className="landing-3d">3D</span>
+            </h1>
+            <p>
+              Precision real-time weather patterns, dynamic storm animations, and
+              hyper-local insights powered by global satellite networks.
+            </p>
+            <div className="landing-hero-cta">
+              <button className="landing-btn-primary" onClick={onExplore}>
+                Explore the Globe
+              </button>
+              <button className="landing-btn-secondary">
+                Watch Video Tour
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Advanced Forecasting ── */}
+      <section className="landing-features">
+        <div className="landing-section-inner">
+          <h2>Advanced Forecasting</h2>
+          <p className="landing-section-sub">
+            Visualizing complex atmospheric data into stunning interactive experiences.
+          </p>
+          <div className="landing-features-grid">
+            {FEATURES.map(f => (
+              <div key={f.title} className="landing-feature-card">
+                <div className="lfc-icon">{f.icon}</div>
+                <h3>{f.title}</h3>
+                <p>{f.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Regional Deep-Dive ── */}
+      <section className="landing-regions">
+        <div className="landing-section-inner">
+          <h2>Regional Deep-Dive</h2>
+          <div className="landing-regions-grid">
+            {REGIONS.map(r => (
+              <div key={r.name} className={`landing-region-card ${r.cls}`}>
+                <div className="lrc-overlay" />
+                <div className="lrc-name">{r.name}</div>
+                <div className="lrc-bottom">
+                  <span className="lrc-condition">{r.condition}</span>
+                  <span className="lrc-temp">{r.temp}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── Footer ── */}
+      <footer className="landing-footer">
+        <div className="landing-footer-inner">
+          <div className="landing-footer-brand">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.3)" strokeWidth="1.8">
+              <circle cx="12" cy="12" r="10"/>
+              <path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
+            </svg>
+            <span>Weather<br />World</span>
+          </div>
+          <a href="#">Privacy Policy</a>
+          <a href="#">Terms of Service</a>
+          <a href="#">API Access</a>
+          <a href="#">Contact</a>
+          <span className="landing-footer-copy">© 2024 Weather World. Satellite Imagery by GlobaNat.</span>
+        </div>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
- New LandingPage component with sticky navbar (logo, nav links, search, Sign In)
- Hero section with Earth globe image, floating city weather cards (Tokyo, London, New York), headline and CTA buttons
- 'Explore the Globe' button transitions to the existing globe application
- 'Advanced Forecasting' features section with 3 cards
- 'Regional Deep-Dive' section with city gradient cards (Tokyo, New York, London, Dubai)
- Footer with links and copyright
- App.css updated: overflow moved to .app class so landing page can scroll

https://claude.ai/code/session_01W5Ro8xoYzwsSVxAbbKtBE3