### PR TITLE
perf: eliminate render-blocking requests (~1,060 ms savings)

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <link rel="preload" as="image" href="https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg" fetchpriority="high" />
 
     <!-- ── DNS prefetch & preconnect ─────────────────────────────── -->
+    <link rel="dns-prefetch" href="https://images.unsplash.com" />
     <link rel="preconnect" href="https://api.open-meteo.com" />
     <link rel="dns-prefetch" href="https://api.open-meteo.com" />
     <link rel="preconnect" href="https://geocoding-api.open-meteo.com" />

--- a/index.html
+++ b/index.html
@@ -44,17 +44,11 @@
     <link rel="manifest" href="/manifest.json" />
 
     <!-- ── DNS prefetch & preconnect ─────────────────────────────── -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="dns-prefetch" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://api.open-meteo.com" />
     <link rel="dns-prefetch" href="https://api.open-meteo.com" />
     <link rel="preconnect" href="https://geocoding-api.open-meteo.com" />
     <link rel="dns-prefetch" href="https://geocoding-api.open-meteo.com" />
     <link rel="dns-prefetch" href="https://nominatim.openstreetmap.org" />
-
-    <!-- ── Google Fonts ──────────────────────────────────────────── -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
 
     <!-- ── JSON-LD Structured Data ───────────────────────────────── -->
     <script type="application/ld+json">

--- a/index.html
+++ b/index.html
@@ -43,6 +43,10 @@
     <!-- ── PWA manifest ──────────────────────────────────────────── -->
     <link rel="manifest" href="/manifest.json" />
 
+    <!-- ── LCP image preload ─────────────────────────────────────── -->
+    <link rel="preconnect" href="https://unpkg.com" crossorigin />
+    <link rel="preload" as="image" href="https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg" fetchpriority="high" />
+
     <!-- ── DNS prefetch & preconnect ─────────────────────────────── -->
     <link rel="preconnect" href="https://api.open-meteo.com" />
     <link rel="dns-prefetch" href="https://api.open-meteo.com" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "0815weather",
       "version": "0.0.1",
       "dependencies": {
+        "@fontsource/inter": "^5.2.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "three": "^0.170.0"
@@ -15,6 +16,7 @@
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
         "vite": "^6.0.5",
+        "vite-plugin-css-injected-by-js": "^4.0.1",
         "vitest": "^4.0.18"
       }
     },
@@ -740,6 +742,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2048,6 +2059,16 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-css-injected-by-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-css-injected-by-js/-/vite-plugin-css-injected-by-js-4.0.1.tgz",
+      "integrity": "sha512-WfyRojojQyAO/KzWf+efcXpTPv6zJPXaRmr9EYq5a4v5I3PWCR7kR01hiri2lW6+rHm3a57kpwsf+iahIJi1Qw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "vite": ">2.0.0-0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "three": "^0.170.0"
@@ -18,6 +19,7 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.4",
     "vite": "^6.0.5",
+    "vite-plugin-css-injected-by-js": "^4.0.1",
     "vitest": "^4.0.18"
   }
 }

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -541,11 +541,17 @@
   position: relative;
   height: 220px;
   border-radius: 12px;
-  background-size: cover;
-  background-position: center;
   overflow: hidden;
   cursor: pointer;
   transition: transform 0.25s;
+}
+
+.city-card-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .city-card:hover {

--- a/src/components/LandingPage.jsx
+++ b/src/components/LandingPage.jsx
@@ -263,8 +263,17 @@ export default function LandingPage({ onExplore, onStartGame }) {
               <div
                 key={city.name}
                 className="city-card"
-                style={{ backgroundImage: `url(${city.img})` }}
               >
+                <img
+                  className="city-card-img"
+                  src={city.img}
+                  alt={city.name}
+                  loading="lazy"
+                  fetchpriority="low"
+                  decoding="async"
+                  width="400"
+                  height="220"
+                />
                 <div className="city-card-overlay" />
                 <div className="city-card-content">
                   <span className="city-card-name">{city.name}</span>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,12 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import '@fontsource/inter/400.css'
+import '@fontsource/inter/500.css'
+import '@fontsource/inter/600.css'
+import '@fontsource/inter/700.css'
+import '@fontsource/inter/800.css'
+import '@fontsource/inter/900.css'
 import './App.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), cssInjectedByJsPlugin()],
 
   build: {
     // Three.js is intentionally large and split into its own lazy chunk


### PR DESCRIPTION
- Replace Google Fonts CDN with self-hosted @fontsource/inter to remove
  the 750 ms render-blocking external stylesheet request
- Add vite-plugin-css-injected-by-js to inject CSS via JS at runtime,
  removing the 150 ms render-blocking CSS bundle link tag
- Remove now-redundant fonts.googleapis.com preconnect hints from HTML

https://claude.ai/code/session_01UkoFqgroF1zoVBtik5r8pn