### PR TITLE
fix: pass mountSizeRef to CityLabels to prevent crash on globe click

### DIFF
--- a/src/components/Globe.jsx
+++ b/src/components/Globe.jsx
@@ -504,6 +504,7 @@ const Globe = forwardRef(function Globe(
         globeRef={globeRef}
         cameraRef={cameraRef}
         mountRef={mountRef}
+        mountSizeRef={mountSizeRef}
         selectedLocation={selectedLocation}
         cityLabels={cityLabels}
       />
@@ -512,7 +513,7 @@ const Globe = forwardRef(function Globe(
 });
 
 // ── HTML labels for selected city + ticker (max ~6, no perf concern) ──
-function CityLabels({ globeRef, cameraRef, mountRef, selectedLocation, cityLabels }) {
+function CityLabels({ globeRef, cameraRef, mountRef, mountSizeRef, selectedLocation, cityLabels }) {
   useEffect(() => {
     if (!selectedLocation) return;
     const globe  = globeRef.current;


### PR DESCRIPTION
CityLabels accessed mountSizeRef.current (for label positioning) but
mountSizeRef was never passed as a prop — only defined as a local ref
inside Globe. On initial load the early-return guard (refs not yet set)
masked the bug, but clicking the globe changes selectedLocation, re-runs
the effect with refs populated, and then hit ReferenceError: mountSizeRef
is not defined.

https://claude.ai/code/session_016UtV7U7vzNShfR9pBsXwis