### PR TITLE
Fix country name blink on Next Round click

### DIFF
--- a/src/components/GameMode.jsx
+++ b/src/components/GameMode.jsx
@@ -204,7 +204,10 @@ export default function GameMode({ onExit, onPlayAgain, showGlobe, onToggleGlobe
 
   function handleNext() {
     if (round + 1 >= TOTAL_ROUNDS) setStatus('gameover');
-    else setRound(r => r + 1);
+    else {
+      setStatus('guessing');
+      setRound(r => r + 1);
+    }
   }
 
   // ── Difficulty picker ──────────────────────────────────────────────


### PR DESCRIPTION
When handleNext() called setRound(), the new city was immediately
reflected in the city variable while status was still 'correct'/'skipped',
causing the result card to briefly display the next round's answer.

Batching setStatus('guessing') with setRound() in the same event handler
prevents this flash by ensuring both updates render together.

https://claude.ai/code/session_01LqVxzzrEiTZk7KX5akZkAm